### PR TITLE
Add central README for OctoAcme project management docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,74 @@
+# OctoAcme Project Management Process Documentation
+
+Welcome to the OctoAcme project management documentation hub! This collection of documents centralizes all our process knowledge so the whole team can access, reference, and improve it over time.
+
+## Purpose
+
+- Centralizes project management knowledge to prevent knowledge silos
+- Gives all team members a single source of truth for processes, decisions, and rationale
+- Accelerates onboarding and maintains repeatable project execution
+
+## OctoAcme Project Management Processes — Overview
+
+OctoAcme project management blends agile best practices with strong documentation and clear roles. Here's a quick overview of our approach:
+
+### Core Lifecycle Phases
+
+1. **Project Initiation:** Validate ideas, align stakeholders, confirm business need, and create a lightweight plan with success metrics
+2. **Project Planning:** Break work into shippable increments, estimate scope, define acceptance criteria, and identify dependencies
+3. **Execution & Tracking:** Build incrementally using project boards, enforce small PRs, run CI/CD, and maintain regular team rhythm (standups, demos, reviews)
+4. **Risk Management & Communication:** Maintain a risk register, communicate status and blockers clearly, and escalate as needed through defined channels
+5. **Release & Deployment:** Follow structured checklists, conduct smoke tests, document rollback plans, and announce releases
+6. **Retrospective & Continuous Improvement:** Capture learnings, convert insights into action items, and measure improvement impact
+
+### Key Principles
+
+- **Customer-first:** Prioritize customer value and usability
+- **Iterative delivery:** Deliver small, testable increments
+- **Clear ownership:** Each project has a named Project Manager (PM) and Product Lead
+- **Data-informed decisions:** Measure impact and iterate based on evidence
+- **Psychological safety:** Encourage feedback and learning
+
+### Core Roles
+
+- **Project Manager:** Coordinates delivery, schedules, risks, and communications
+- **Product Manager:** Defines outcomes, prioritizes backlog, measures success
+- **Developers:** Implement features, collaborate on design and testability
+- **QA/Testing:** Validates quality and acceptance criteria
+- **Stakeholders:** Provide inputs, approvals, and feedback
+
+## How to Use These Docs
+
+- **Start here:** Read "Project Management Overview" for the 30,000-foot view
+- **Deep dive by phase:** Select a doc that matches your current project stage
+- **Reference:** Use checklists and templates from each document to guide your work
+- **Improve:** Submit process updates via our "Add Content to Project Management Process Docs" issue template
+
+## Documentation Index
+
+| Document | Purpose |
+|----------|---------|
+| [Project Management Overview](octoacme-project-management-overview.md) | High-level introduction to OctoAcme's approach, roles, and lifecycle |
+| [Project Initiation](octoacme-project-initiation.md) | Steps to validate ideas, align stakeholders, and authorize work |
+| [Project Planning](octoacme-project-planning.md) | How to break work into increments, estimate, and build your backlog |
+| [Execution and Tracking](octoacme-execution-and-tracking.md) | Daily standup rhythm, PR workflow, quality gates, and reporting |
+| [Risks and Communication](octoacme-risks-and-communication.md) | Risk register management, escalation paths, and stakeholder updates |
+| [Release and Deployment](octoacme-release-and-deployment.md) | Pre-release checklist, deployment steps, rollback procedures |
+| [Retrospective and Continuous Improvement](octoacme-retrospective-and-continuous-improvement.md) | How to run retros and turn learnings into action items |
+| [Roles and Personas](octoacme-roles-and-personas.md) | Detailed responsibilities and goals for each team member role |
+
+## Getting Started
+
+1. **New to OctoAcme projects?** Start with "Project Management Overview"
+2. **Kicking off a project?** Follow the "Project Initiation" and "Project Planning" guides
+3. **In delivery?** Reference "Execution and Tracking" and "Risks and Communication"
+4. **Preparing a release?** Use the "Release and Deployment" checklist
+5. **After a project milestone?** Schedule a retrospective using "Retrospective and Continuous Improvement"
+
+## Contributing to These Docs
+
+Have feedback, identified a gap, or want to propose an improvement? Submit a request using the **["Add Content to Project Management Process Docs"](../.github/ISSUE_TEMPLATE/add-update-content-to-process-docs.yml)** issue template.
+
+---
+
+_Last updated: 2026-04-22_


### PR DESCRIPTION
## Overview
This PR adds a comprehensive README to the `docs/` folder to serve as the entry point for OctoAcme's project management documentation.

## Changes
- Added `docs/README.md` with an overview of OctoAcme project management processes
- Summarizes core lifecycle phases and key principles
- Lists all documentation files with brief descriptions
- Provides guidance on how to navigate and use the docs
- Links to the issue template for contributing improvements

## Addresses
Closes #2

## Acceptance Criteria
- [x] Content aligns with existing process docs
- [x] Improves clarity and provides a single entry point for navigation
- [x] Links are relative and functional